### PR TITLE
Update IDs and offsets to match robot

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.hal.HALUtil;
 import edu.wpi.first.util.datalog.DataLog;
 import edu.wpi.first.util.datalog.IntegerLogEntry;
 import edu.wpi.first.wpilibj.DataLogManager;
@@ -20,6 +21,11 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
  */
 public class Robot extends TimedRobot {
   public static final boolean isCompetition = true;
+
+  //RoboRIO serial numbers
+  public static final String competitionRobotSerial = "03161743";
+  public static final String practiceRobotSerial = "03064df0";
+  public static final boolean isCompetitionRobot = !HALUtil.getSerialNumber().equals(practiceRobotSerial);
 
   private Command m_autonomousCommand;
   private DataLog loopCountlog = DataLogManager.getLog();

--- a/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
+++ b/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
@@ -12,9 +12,9 @@ public class AbsoluteEncoder {
         //Swerve Modules
         //Offsets determined by manually turning all modules to 0 (forward) and recording their positions
         FrontLeftModule(1, false, -1.774, -1.12),
-        FrontRightModule(2, false, -1.802),
-        BackLeftModule(3, false, 0.353),
-        BackRightModule(4, false, -0.853);
+        FrontRightModule(2, false, -1.802, -1.078),
+        BackLeftModule(3, false, 0.353, -3.911),
+        BackRightModule(4, false, -0.853, -4.686);
         
         private int ID;
         private boolean reversed;

--- a/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
+++ b/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
@@ -18,14 +18,14 @@ public class AbsoluteEncoder {
         
         private int ID;
         private boolean reversed;
-        private double offset; //Offset in radians
-        private double altOffset; //Offset in radians, used on practice bot
+        private double competitionOffset; //Offset in radians, used on competition bot
+        private double practiceOffset; //Offset in radians, used on practice bot
     
         EncoderConfig(int ID, boolean reversed, double offset, double altOffset){
             this.ID = ID;
             this.reversed = reversed;
-            this.offset = offset;
-            this.altOffset = altOffset;
+            this.competitionOffset = offset;
+            this.practiceOffset = altOffset;
         }
 
         EncoderConfig(int ID, boolean reversed, double offset){
@@ -48,12 +48,12 @@ public class AbsoluteEncoder {
             return reversed;
         }
 
-        public double getOffset(){
-            return offset;
+        public double getCompetitionOffset(){
+            return competitionOffset;
         }
 
-        public double getAltOffset(){
-            return altOffset;
+        public double getPracticeOffset(){
+            return practiceOffset;
         }
     }
 
@@ -63,7 +63,7 @@ public class AbsoluteEncoder {
         encoder.configSensorInitializationStrategy(SensorInitializationStrategy.BootToAbsolutePosition);
         encoder.configAbsoluteSensorRange(AbsoluteSensorRange.Signed_PlusMinus180);
         encoder.configSensorDirection(config.getReversed());
-        encoder.configMagnetOffset(Units.radiansToDegrees(Robot.isCompetitionRobot ? config.getOffset() : config.getAltOffset()));
+        encoder.configMagnetOffset(Units.radiansToDegrees(Robot.isCompetitionRobot ? config.getCompetitionOffset() : config.getPracticeOffset()));
         return encoder;
     }
 }

--- a/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
+++ b/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
@@ -5,12 +5,13 @@ import com.ctre.phoenix.sensors.SensorInitializationStrategy;
 import com.ctre.phoenix.sensors.WPI_CANCoder;
 
 import edu.wpi.first.math.util.Units;
+import frc.robot.Robot;
 
 public class AbsoluteEncoder {
     public enum EncoderConfig {
         //Swerve Modules
         //Offsets determined by manually turning all modules to 0 (forward) and recording their positions
-        FrontLeftModule(1, false, -1.774),
+        FrontLeftModule(1, false, -1.774, -1.12),
         FrontRightModule(2, false, -1.802),
         BackLeftModule(3, false, 0.353),
         BackRightModule(4, false, -0.853);
@@ -18,19 +19,25 @@ public class AbsoluteEncoder {
         private int ID;
         private boolean reversed;
         private double offset; //Offset in radians
+        private double altOffset; //Offset in radians, used on practice bot
     
-        EncoderConfig(int ID, boolean reversed, double offset){
+        EncoderConfig(int ID, boolean reversed, double offset, double altOffset){
             this.ID = ID;
             this.reversed = reversed;
             this.offset = offset;
+            this.altOffset = altOffset;
+        }
+
+        EncoderConfig(int ID, boolean reversed, double offset){
+            this(ID, reversed, offset, 0);
         }
     
         EncoderConfig(int ID, boolean reversed){
-            this(ID, reversed, 0);
+            this(ID, reversed, 0, 0);
         }
     
         EncoderConfig(int ID){
-            this(ID, false, 0);
+            this(ID, false, 0, 0);
         }
     
         public int getID(){
@@ -44,6 +51,10 @@ public class AbsoluteEncoder {
         public double getOffset(){
             return offset;
         }
+
+        public double getAltOffset(){
+            return altOffset;
+        }
     }
 
     public static WPI_CANCoder constructEncoder(EncoderConfig config){
@@ -52,7 +63,7 @@ public class AbsoluteEncoder {
         encoder.configSensorInitializationStrategy(SensorInitializationStrategy.BootToAbsolutePosition);
         encoder.configAbsoluteSensorRange(AbsoluteSensorRange.Signed_PlusMinus180);
         encoder.configSensorDirection(config.getReversed());
-        encoder.configMagnetOffset(Units.radiansToDegrees(config.getOffset()));
+        encoder.configMagnetOffset(Units.radiansToDegrees(Robot.isCompetitionRobot ? config.getOffset() : config.getAltOffset()));
         return encoder;
     }
 }

--- a/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
+++ b/src/main/java/frc/robot/hardware/AbsoluteEncoder.java
@@ -10,10 +10,10 @@ public class AbsoluteEncoder {
     public enum EncoderConfig {
         //Swerve Modules
         //Offsets determined by manually turning all modules to 0 (forward) and recording their positions
-        FrontLeftModule(12, false, -1.12),
-        FrontRightModule(11, false, -1.078),
-        BackLeftModule(10, false, -3.911),
-        BackRightModule(9, false, -4.686);
+        FrontLeftModule(1, false, -1.774),
+        FrontRightModule(2, false, -1.802),
+        BackLeftModule(3, false, 0.353),
+        BackRightModule(4, false, -0.853);
         
         private int ID;
         private boolean reversed;

--- a/src/main/java/frc/robot/hardware/MotorController.java
+++ b/src/main/java/frc/robot/hardware/MotorController.java
@@ -13,18 +13,17 @@ public class MotorController {
 
     public static enum MotorConfig {
         //Swerve Modules
-        FrontLeftModuleDrive(4, 50, IdleMode.kBrake),
-        FrontLeftModuleTurn(3, 40, IdleMode.kBrake, true),
+        FrontLeftModuleDrive(20, 50, IdleMode.kBrake),
+        FrontLeftModuleTurn(19, 40, IdleMode.kBrake, true),
         FrontRightModuleDrive(2, 50, IdleMode.kBrake),
         FrontRightModuleTurn(1, 40, IdleMode.kBrake, true),
-        BackLeftModuleDrive(7, 50, IdleMode.kBrake),
-        BackLeftModuleTurn(8, 40, IdleMode.kBrake, true),
-        BackRightModuleDrive(6, 50, IdleMode.kBrake),
-        BackRightModuleTurn(5, 40, IdleMode.kBrake, true),  
+        BackLeftModuleDrive(11, 50, IdleMode.kBrake),
+        BackLeftModuleTurn(12, 40, IdleMode.kBrake, true),
+        BackRightModuleDrive(10, 50, IdleMode.kBrake),
+        BackRightModuleTurn(9, 40, IdleMode.kBrake, true),
         //Intake motors
         IntakeMotor1(13),
         IntakeMotor2(14); //TODO update to real hardware IDs
-    
 
         private int ID;
         private int currentLimit;

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -197,5 +197,6 @@ public class SwerveModule extends SubsystemBase {
         actualSpeedLog.append(driveEncoder.getVelocity());
         actualAbsoluteAngleLog.append(getAbsoluteTurningPosition());
         actualRelativeAngleLog.append(getTurningPosition());
+        SmartDashboard.putNumber("Swerve Module " + ID + " absolute encoder", getAbsoluteTurningPosition());
     }
 }

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -197,6 +197,5 @@ public class SwerveModule extends SubsystemBase {
         actualSpeedLog.append(driveEncoder.getVelocity());
         actualAbsoluteAngleLog.append(getAbsoluteTurningPosition());
         actualRelativeAngleLog.append(getTurningPosition());
-        SmartDashboard.putNumber("Swerve Module " + ID + " absolute encoder", getAbsoluteTurningPosition());
     }
 }

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -34,8 +34,8 @@ public class SwerveSubsystem extends SubsystemBase{
     public static final double kPhysicalMaxSpeed = Units.feetToMeters(14.5);; //Max drivebase speed in meters per second
     public static final double kPhysicalMaxAngularSpeed = 2 * Math.PI; //Max drivebase angular speed in radians per second
 
-    public static final double kTrackWidth = Units.inchesToMeters(18.75); //Distance between right and left wheels
-    public static final double kWheelBase = Units.inchesToMeters(18.75); //Distance between front and back wheels
+    public static final double kTrackWidth = Units.inchesToMeters(19.75); //Distance between right and left wheels
+    public static final double kWheelBase = Units.inchesToMeters(19.75); //Distance between front and back wheels
     public static final SwerveDriveKinematics kDriveKinematics = new SwerveDriveKinematics( //Creates robot geometry using the locations of the 4 wheels
         new Translation2d(kWheelBase / 2, kTrackWidth / 2), 
         new Translation2d(kWheelBase / 2, -kTrackWidth /2),


### PR DESCRIPTION
# Pull Request Details
Note: we should find a way for code to work on both robots, even though they have differing hardware
<!--- The title of the PR should summarize the change implemented. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Allows us to use the new competition robot

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which does this affect?
IDs in MotorController
IDs and offsets in AbsoluteEncoder
Kinematics in SwerveSubsystem

## Testing Done
Ran some basic ROD drive tests, have not been able to test driving as the battery is not secured

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] My code follows the code style of this project.
- [x] My code has been tested on the Robot OR includes simulation code to prove functionality.
