### PR TITLE
Close CANCoders after use

### DIFF
--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -66,8 +66,7 @@ public class SwerveModule extends SubsystemBase {
     private DoubleLogEntry desiredSpeedLog;
     private DoubleLogEntry actualSpeedLog;
     private DoubleLogEntry desiredAngleLog;
-    private DoubleLogEntry actualAbsoluteAngleLog;
-    private DoubleLogEntry actualRelativeAngleLog;
+    private DoubleLogEntry actualAngleLog;
     private DoubleLogEntry rotationSpeedLog;
 
     private final String ID;
@@ -113,8 +112,7 @@ public class SwerveModule extends SubsystemBase {
         desiredSpeedLog = new DoubleLogEntry(datalog, "/swerve/" + ID +"/setSpeed"); //Logs desired speed in meters per second
         actualSpeedLog = new DoubleLogEntry(datalog, "/swerve/" + ID +"/setSpeed"); //Logs actual speed in meters per second
         desiredAngleLog = new DoubleLogEntry(datalog, "/swerve/" + ID +"/setAngle"); //Logs desired angle in radians
-        actualAbsoluteAngleLog = new DoubleLogEntry(datalog, "/swerve/" + ID +"/actualAbsAngle"); //Logs actual absolute angle in radians
-        actualRelativeAngleLog = new DoubleLogEntry(datalog, "/swerve/" + ID +"/actualRelAngle"); //Logs actual relative angle in radians
+        actualAngleLog = new DoubleLogEntry(datalog, "/swerve/" + ID +"/actualAngle"); //Logs actual relative angle in radians
     }
 
     public SwerveModulePosition getPosition() {
@@ -147,6 +145,7 @@ public class SwerveModule extends SubsystemBase {
     public void resetEncoders() {
         driveEncoder.setPosition(0);
         turningEncoder.setPosition(getAbsoluteTurningPosition());
+        absoluteEncoder.close();
     }
 
     public SwerveModuleState getState() {
@@ -218,7 +217,6 @@ public class SwerveModule extends SubsystemBase {
     @Override
     public void periodic(){
         actualSpeedLog.append(driveEncoder.getVelocity());
-        actualAbsoluteAngleLog.append(getAbsoluteTurningPosition());
-        actualRelativeAngleLog.append(getTurningPosition());
+        actualAngleLog.append(getTurningPosition());
     }
 }

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -145,7 +145,9 @@ public class SwerveModule extends SubsystemBase {
     public void resetEncoders() {
         driveEncoder.setPosition(0);
         turningEncoder.setPosition(getAbsoluteTurningPosition());
-        absoluteEncoder.close();
+        if(Robot.isReal()){
+            absoluteEncoder.close();
+        }
     }
 
     public SwerveModuleState getState() {


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Close our CANCoders after we use them, to prevent the CANCoders from using too much of our CANBus
Needs testing to prove whether this actually lessens CAN utilization

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which does this affect?
<!--- Include areas/subsystems that are affected and some details on what -->
<!--- areas these changes affect. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] My code follows the code style of this project.
- [ ] My code has been tested on the Robot OR includes simulation code to prove functionality.
