### PR TITLE
Assisted balance fixes

### DIFF
--- a/src/main/java/frc/robot/classes/Auton.java
+++ b/src/main/java/frc/robot/classes/Auton.java
@@ -159,14 +159,14 @@ public class Auton{
                     new SequentialCommandGroup(
                         resetOdometry("1ScoreCharge-1"),
                         swerveSubsystem.followTrajectory("1ScoreCharge-1", getTrajectory("1ScoreCharge-1")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case CHARGE6:
                 return
                     new SequentialCommandGroup(
                         resetOdometry("1ScoreCharge-6"),
                         swerveSubsystem.followTrajectory("1ScoreCharge-6", getTrajectory("1ScoreCharge-6")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case ONESCORECHARGE1:
                 return
@@ -175,7 +175,7 @@ public class Auton{
                         highScoreSequence(),
                         swerveSubsystem.followTrajectory("1ScoreCharge-1", getTrajectory("1ScoreCharge-1"))
                         .deadlineWith(armSubsystem.stowArmParallel()),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case ONESCORECHARGE2:
                 return
@@ -184,7 +184,7 @@ public class Auton{
                         highScoreSequence(),
                         swerveSubsystem.followTrajectory("1ScoreCharge-2", getTrajectory("1ScoreCharge-2"))
                         .alongWith(armSubsystem.stowArmParallel()),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case ONESCORECHARGE3:
                 return
@@ -193,7 +193,7 @@ public class Auton{
                         highScoreSequence(),
                         swerveSubsystem.followTrajectory("1ScoreCharge-3", getTrajectory("1ScoreCharge-3"))
                         .alongWith(armSubsystem.stowArmParallel()),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case ONESCORECHARGE4:
                 return
@@ -202,7 +202,7 @@ public class Auton{
                         highScoreSequence(),
                         swerveSubsystem.followTrajectory("1ScoreCharge-4", getTrajectory("1ScoreCharge-4"))
                         .alongWith(armSubsystem.stowArmParallel()),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case ONESCORECHARGE5:
                 return
@@ -211,7 +211,7 @@ public class Auton{
                         highScoreSequence(),
                         swerveSubsystem.followTrajectory("1ScoreCharge-5", getTrajectory("1ScoreCharge-5"))
                         .alongWith(armSubsystem.stowArmParallel()),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case ONESCORECHARGE6:
                 return
@@ -220,7 +220,7 @@ public class Auton{
                         highScoreSequence(),
                         swerveSubsystem.followTrajectory("1ScoreCharge-6", getTrajectory("1ScoreCharge-6"))
                         .alongWith(armSubsystem.stowArmParallel()),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case TWOSCORE1:
                 return
@@ -249,7 +249,7 @@ public class Auton{
                         .alongWith(armSubsystem.stowArmParallel()),
                         swerveSubsystem.followTrajectory("2ScoreCharge2-1", getTrajectory("2ScoreCharge2-1")),
                         swerveSubsystem.followTrajectory("2ScoreCharge3-1", getTrajectory("2ScoreCharge3-1")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case TWOSCORECHARGE6:
                 return
@@ -260,7 +260,7 @@ public class Auton{
                         .alongWith(armSubsystem.stowArmParallel()),
                         swerveSubsystem.followTrajectory("2ScoreCharge2-6", getTrajectory("2ScoreCharge2-6")),
                         swerveSubsystem.followTrajectory("2ScoreCharge3-6", getTrajectory("2ScoreCharge3-6")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case THREESCORE1:
                 return
@@ -294,7 +294,7 @@ public class Auton{
                         swerveSubsystem.followTrajectory("2ScoreLoadCharge2-1", getTrajectory("2ScoreLoadCharge2-1")),
                         swerveSubsystem.followTrajectory("2ScoreLoadCharge3-1", getTrajectory("2ScoreLoadCharge3-1")),
                         swerveSubsystem.followTrajectory("2ScoreLoadCharge4-1", getTrajectory("2ScoreLoadCharge4-1")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case TWOSCORELOADCHARGE6:
                 return
@@ -306,7 +306,7 @@ public class Auton{
                         swerveSubsystem.followTrajectory("2ScoreLoadCharge2-6", getTrajectory("2ScoreLoadCharge2-6")),
                         swerveSubsystem.followTrajectory("2ScoreLoadCharge3-6", getTrajectory("2ScoreLoadCharge3-6")),
                         swerveSubsystem.followTrajectory("2ScoreLoadCharge4-6", getTrajectory("2ScoreLoadCharge4-6")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case THREESCORECHARGE1:
                 return
@@ -319,7 +319,7 @@ public class Auton{
                         swerveSubsystem.followTrajectory("3ScoreCharge3-1", getTrajectory("3ScoreCharge3-1")),
                         swerveSubsystem.followTrajectory("3ScoreCharge4-1", getTrajectory("3ScoreCharge4-1")),
                         swerveSubsystem.followTrajectory("3ScoreCharge5-1", getTrajectory("3ScoreCharge5-1")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             case THREESCORECHARGE6:
                 return
@@ -332,7 +332,7 @@ public class Auton{
                         swerveSubsystem.followTrajectory("3ScoreCharge3-6", getTrajectory("3ScoreCharge3-6")),
                         swerveSubsystem.followTrajectory("3ScoreCharge4-6", getTrajectory("3ScoreCharge4-6")),
                         swerveSubsystem.followTrajectory("3ScoreCharge5-6", getTrajectory("3ScoreCharge5-6")),
-                        swerveSubsystem.assistedBalance()
+                        swerveSubsystem.assistedBalance(true)
                     );
             default:
                 return null;

--- a/src/main/java/frc/robot/commands/AssistedBalanceCommand.java
+++ b/src/main/java/frc/robot/commands/AssistedBalanceCommand.java
@@ -18,6 +18,7 @@ public class AssistedBalanceCommand extends CommandBase {
   private final double kDBalancing = 0;
   private final double balancingDeadzoneNumber = 2.5;
   private double pidControllerMaxSpeed = 0.15;
+  private boolean reversed = false;
   PIDController pidController = new PIDController(kPBalancing, kIBalancing, kDBalancing);
   
   /**
@@ -25,12 +26,13 @@ public class AssistedBalanceCommand extends CommandBase {
    *
    * @param subsystem The subsystem used by this command.
    */
-  public AssistedBalanceCommand(SwerveSubsystem swerveSubsystem) {
+  public AssistedBalanceCommand(SwerveSubsystem swerveSubsystem, boolean reverse) {
     swerve_subsystem = swerveSubsystem;
     pidController.setTolerance(balancingDeadzoneNumber);
 
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(swerveSubsystem); 
+    reversed = reverse;
   }
 
   // Called when the command is initially scheduled.
@@ -42,7 +44,7 @@ public class AssistedBalanceCommand extends CommandBase {
   public void execute() {
     swerve_subsystem.setModuleStates(
       swerve_subsystem.convertToModuleStates(
-        0.0, MathUtil.clamp(-pidController.calculate(swerve_subsystem.getPitch(), 0.0), -pidControllerMaxSpeed, pidControllerMaxSpeed), 0.0));  
+        0.0, MathUtil.clamp((reversed?-1:1)*pidController.calculate(swerve_subsystem.getPitch(), 0.0), -pidControllerMaxSpeed, pidControllerMaxSpeed), 0.0));  
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -302,8 +302,8 @@ public class SwerveSubsystem extends SubsystemBase{
         ).alongWith(new InstantCommand(() -> Logger.getInstance().recordOutput("trajectory " + name, trajectory)));
     }
 
-    public Command assistedBalance(){
-        return new AssistedBalanceCommand(this);
+    public Command assistedBalance(boolean reversed){
+        return new AssistedBalanceCommand(this, reversed);
     }
     
     @Override


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
Allows the assisted balance to go up the charge station when the robot is reversed.
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
The code creates a parameter for the assisted balance command called reversed which will reverse the direction of the pid controller depending on the orientation of the robot.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
fixes the assisted balance not working depending on the robot's yaw orientation
## Which does this affect?
<!--- Include areas/subsystems that are affected and some details on what -->
<!--- areas these changes affect. -->
swerveSubsystem
Auton
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Can test when the main robot is no longer being fixed
## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] My code follows the code style of this project.
- [ ] My code has been tested on the Robot OR includes simulation code to prove functionality.
