### PR TITLE
Prevent duplicate Shuffleboared Entries

### DIFF
--- a/src/main/java/frc/robot/classes/DebugLog.java
+++ b/src/main/java/frc/robot/classes/DebugLog.java
@@ -1,5 +1,7 @@
 package frc.robot.classes;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.function.Consumer;
 
 import edu.wpi.first.networktables.GenericEntry;
@@ -13,6 +15,7 @@ import frc.robot.Robot;
 
 public class DebugLog<T> {
     private static DataLog datalog = DataLogManager.getLog();
+    private static HashMap<Integer,String> entrys = new HashMap<Integer,String>();
 
     private ShuffleboardTab networkTab;
     private GenericEntry networkEntry;
@@ -37,7 +40,11 @@ public class DebugLog<T> {
         if (localEntry != null) {
             if(!Robot.isCompetition){
                 networkTab = Shuffleboard.getTab(subsystem.getName());
-                networkEntry = networkTab.add(name, defaultValue).getEntry();
+
+                if (!entrys.containsValue(name)) {
+                    networkEntry = networkTab.add(name, defaultValue).getEntry();
+                    entrys.put(entrys.size(), name);
+                }
             }
             localConsumer.accept(defaultValue);
         }
@@ -46,7 +53,9 @@ public class DebugLog<T> {
     public void log(T newValue){
         try{
             if(!Robot.isCompetition){
-                networkEntry.setValue(newValue);
+                if (networkEntry != null) {
+                    networkEntry.setValue(newValue);
+                }
             }
             localConsumer.accept(newValue);
         } catch(NullPointerException e){

--- a/src/main/java/frc/robot/classes/DebugLog.java
+++ b/src/main/java/frc/robot/classes/DebugLog.java
@@ -14,7 +14,7 @@ import frc.robot.Robot;
 
 public class DebugLog<T> {
     private static DataLog datalog = DataLogManager.getLog();
-    private static HashMap<Integer,String> entrys = new HashMap<Integer,String>();
+    private static HashMap<String,GenericEntry> entries = new HashMap<String,GenericEntry>();
 
     private ShuffleboardTab networkTab;
     private GenericEntry networkEntry;
@@ -40,9 +40,12 @@ public class DebugLog<T> {
             if(!Robot.isCompetition){
                 networkTab = Shuffleboard.getTab(subsystem.getName());
 
-                if (!entrys.containsValue(name)) {
+                if (!entries.containsKey(name)) {
                     networkEntry = networkTab.add(name, defaultValue).getEntry();
-                    entrys.put(entrys.size(), name);
+                    entries.put(name, networkEntry);
+                } else {
+                    networkEntry = entries.get(name);
+                    DriverStation.reportWarning("Duplicate ShuffleboardEntry on " + networkTab.getTitle() + " tab: " + name, false);
                 }
             }
             localConsumer.accept(defaultValue);
@@ -52,9 +55,7 @@ public class DebugLog<T> {
     public void log(T newValue){
         try{
             if(!Robot.isCompetition){
-                if (networkEntry != null) {
-                    networkEntry.setValue(newValue);
-                }
+                networkEntry.setValue(newValue);
             }
             localConsumer.accept(newValue);
         } catch(NullPointerException e){

--- a/src/main/java/frc/robot/classes/DebugLog.java
+++ b/src/main/java/frc/robot/classes/DebugLog.java
@@ -1,7 +1,6 @@
 package frc.robot.classes;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.function.Consumer;
 
 import edu.wpi.first.networktables.GenericEntry;


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Unit tests that use DebugLog cause duplicate Shuffleboard entries to be created. Addition keeps track of entry names in a HashMap and skips creating a new entry if it is a duplicate.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which does this affect?
<!--- Include areas/subsystems that are affected and some details on what -->
<!--- areas these changes affect. -->
DebugLog class

Unit testing

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] My code follows the code style of this project.
- [x] My code has been tested on the Robot OR includes simulation code to prove functionality.
